### PR TITLE
Added restore feature and bug fixes

### DIFF
--- a/configs/nps/catalog.cfg
+++ b/configs/nps/catalog.cfg
@@ -11,6 +11,14 @@
       "shortcut"                "heal"
       "must_be_incapacitated"   "1"
     }
+    "extinguish"
+    {
+      "name"                    "Self-Extinguish"
+      "cost"                    "10"
+      "shortcut"                "extinguish"
+      "team"                    "infected"
+      "announce"                "1"
+    }
     "ammo"
     {
       "name"              "Refill Ammo"

--- a/configs/nps/menus.cfg
+++ b/configs/nps/menus.cfg
@@ -10,6 +10,7 @@
   "infected_menu"
   {
     "heal"            "Heal"
+    "extinguish"      "Self-Extinguish"
     "boomer"          "Boomer"
     "charger"         "Charger"
     "jockey"          "Jockey"

--- a/scripting/include/nps.inc
+++ b/scripting/include/nps.inc
@@ -1,0 +1,16 @@
+#if defined _nps_included
+  #endinput
+#endif
+#define _nps_included
+
+forward void NPS_OnPlayerBuyZombie(int client);
+
+public SharedPlugin __pl_nps = {
+  name = "nps",
+  file = "nps.smx",
+#if defined REQUIRE_PLUGIN
+  required = 1,
+#else
+  required = 0,
+#endif
+};

--- a/scripting/nps_rewards.sp
+++ b/scripting/nps_rewards.sp
@@ -193,8 +193,6 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
   int attacker = GetClientOfUserId(event.GetInt("attacker"));
   //bool headshot = event.GetBool("headshot");
 
-  (new Player(victim)).HealCount = 0;
-
   if (!IsValidClient(attacker)) return Plugin_Continue;
   if (IsPlayerSurvivor(attacker)) {
     if (!IsPlayerInfected(victim)) return Plugin_Continue;

--- a/translations/nps_core.phrases.txt
+++ b/translations/nps_core.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+  "Points Restore"
+  {
+    "en"       "Your points have been restored"
+  }
   "Reward"
   {
     "#format"   "{1:i}"

--- a/translations/nps_core.phrases.txt
+++ b/translations/nps_core.phrases.txt
@@ -83,6 +83,10 @@
   {
     "en"        "You must be incapacitated to do this."
   }
+  "Must Be On Fire"
+  {
+    "en"        "You must be on fire to do this."
+  }
   "Must Not Be Grabbed"
   {
     "en"        "You can not do this while grabbed."
@@ -282,6 +286,11 @@
   "Tank Not Allowed in Final"
   {
     "en"        "Tank is not allowed in final."
+  }
+  "Self-Extinguish"
+  {
+    "#format"   "{1:N}"
+    "en"        "{lightgreen}{1}{default} purchased a {lightgreen}self-extinguish{default}"
   }
   "Announce Witch Purchase"
   {

--- a/translations/ru/nps_core.phrases.txt
+++ b/translations/ru/nps_core.phrases.txt
@@ -83,6 +83,10 @@
   {
     "ru"        "Вы должны быть выведены из строя, чтобы сделать это."
   }
+  "Must Be On Fire"
+  {
+    "ru"        "Вы должны гореть, чтобы сделать это."
+  }
   "Must Not Be Grabbed"
   {
     "ru"        "Вы не можете сделать это, пока вас схватили."
@@ -282,6 +286,11 @@
   "Tank Not Allowed in Final"
   {
     "ru"        "Танк не допускается в конце."
+  }
+  "Self-Extinguish"
+  {
+    "#format"   "{1:N}"
+    "ru"        "{lightgreen}{1}{default} потушил себя"
   }
   "Announce Witch Purchase"
   {

--- a/translations/ru/nps_core.phrases.txt
+++ b/translations/ru/nps_core.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+  "Points Restore"
+  {
+    "ru"       "Ваши очки были восстановлены"
+  }
   "Reward"
   {
     "#format"   "{1:i}"


### PR DESCRIPTION
- If you're a survivor and you get incapacitated then purchase a heal. Then if you switch teams and get control of a tank and purchase a heal for your tank it's gonna count that survivor heal (from earlier) as 1 heal (1/3) so the tank heal will start from 2/3. Same as if you healed twice as a survivor then switch. It's gonna start from 2/3 for tank.
- If you're a tank and you purchase heal (1/3) then die. After death if you press the USE (E) key it's gonna continue those heal counts and waste your points 2/3. 3/3 etc this heal count will also carry to over to the next time you're put in control of the tank. If you previously died as a tank with 1/3, after death you press E (which is for !buy heal command), 2/3. Then next time you're a tank it's gonna be 3/3 if you try to heal. Basically make sure there is no way tank should be able to heal more or less than 3 times at any condition.
- A bug where if player purchase a special infected during the death countdown (20 seconds countdown after death). Once the countdown ends, it switches the purchased infected to a random one. This bug is caused by another plugin (l4d2_zcs - zombie character select). Added NpsOnPlayerBuyZombie fwd.
Features:
- Restore players points if they disconnect and reconnect within X seconds.