### PR TITLE
Some cool stuff here.

### DIFF
--- a/scripting/nps.sp
+++ b/scripting/nps.sp
@@ -3,7 +3,7 @@
 #include <clientprefs>
 #include <colors>
 
-#define NYXTOOLS_DEBUG 1
+#define NYXTOOLS_DEBUG 0
 #define NYXTOOLS_TAG "PS"
 #define USE_DELAY_SECONDS 2
 #include <nyxtools>

--- a/scripting/nps.sp
+++ b/scripting/nps.sp
@@ -258,7 +258,6 @@ public Action L4D2_OnReplaceTank(int tank, int new_tank) {
 
   return Plugin_Continue;
 }
-#endif
 
 /*
 [Nyx] L4D2_OnReplaceWithBot(client: Kiwi, flag: 0)

--- a/scripting/nps.sp
+++ b/scripting/nps.sp
@@ -704,8 +704,6 @@ public int MenuHandler_GivePoints(Menu menu, MenuAction action, int param1, int 
         Display_GivePointsMenu(param1);
       }
     }
-
-    return;
   } else if (action == MenuAction_Select) {
     char info[32];
     menu.GetItem(param2, info, sizeof(info));
@@ -760,8 +758,6 @@ public int MenuHandler_GiveAmount(Menu menu, MenuAction action, int param1, int 
         Display_GivePointsMenu(param1);
       }
     }
-
-    return;
   } else if (action == MenuAction_Select) {
     char info[32];
     menu.GetItem(param2, info, sizeof(info));
@@ -773,7 +769,7 @@ public int MenuHandler_GiveAmount(Menu menu, MenuAction action, int param1, int 
     } else {
       Player player = new Player(param1);
       if (player.Points < amount) {
-        NyxPrintToChat(param1, "%t", "Insufficient Points", amount);
+        NyxPrintToChat(param1, "%t", "Insufficient Points");
       } else {
         int spent = (new Player(target)).GivePoints(amount);
         player.Points -= spent;

--- a/scripting/nps_catalog.sp
+++ b/scripting/nps_catalog.sp
@@ -1,7 +1,7 @@
 #pragma semicolon 1
 #include <sourcemod>
 
-#define NYX_DEBUG 1
+#define NYXTOOLS_DEBUG 0
 #define NYXTOOLS_TAG "PS"
 #include <nyxtools>
 #include <nyxtools_l4d2>

--- a/scripting/nps_menu.sp
+++ b/scripting/nps_menu.sp
@@ -1,7 +1,7 @@
 #pragma semicolon 1
 #include <sourcemod>
 
-#define NYX_DEBUG 0
+#define NYXTOOLS_DEBUG 0
 #define NYXTOOLS_TAG "PS"
 #include <nyxtools>
 #undef REQUIRE_PLUGIN

--- a/scripting/nps_rewards.sp
+++ b/scripting/nps_rewards.sp
@@ -2,7 +2,7 @@
 #include <sourcemod>
 #include <colors>
 
-#define NYX_DEBUG 1
+#define NYXTOOLS_DEBUG 0
 #define NYXTOOLS_TAG "PS"
 #include <nyxtools>
 #include <nyxtools_l4d2>

--- a/scripting/nps_storage.sp
+++ b/scripting/nps_storage.sp
@@ -1,7 +1,7 @@
 #pragma semicolon 1
 #include <sourcemod>
 
-#define NYX_DEBUG 1
+#define NYXTOOLS_DEBUG 0
 #define NYXTOOLS_TAG "PS"
 #include <nyxtools>
 #include <nps_stocks>

--- a/translations/nps_core.phrases.txt
+++ b/translations/nps_core.phrases.txt
@@ -38,6 +38,21 @@
   {
     "en"        "You don't have enough points."
   }
+  "Insufficient Player Points"
+  {
+	"#format"   "{1:N}"
+    "en"        "{lightgreen}{1}{default} don't have enough points."
+  }
+  "Didn't Agree To Give"
+  {
+	"#format"   "{1:N}"
+    "en"        "{lightgreen}{1}{default} didn't agree to give you points."
+  }
+  "Waiting For Confirmation"
+  {
+	"#format"   "{1:N}"
+    "en"        "Waiting for confirmation from {lightgreen}{1}{default}..."
+  }
   "No Points"
   {
     "en"        "You don't have any points."

--- a/translations/ru/nps_core.phrases.txt
+++ b/translations/ru/nps_core.phrases.txt
@@ -38,6 +38,21 @@
   {
     "ru"        "Вам не хватает очков."
   }
+  "Insufficient Player Points"
+  {
+	"#format"   "{1:N}"
+    "ru"        "Игроку {lightgreen}{1}{default} не хватает очков."
+  }
+  "Didn't Agree To Give"
+  {
+	"#format"   "{1:N}"
+    "ru"        "{lightgreen}{1}{default} не согласился дать вам очков."
+  }
+   "Waiting For Confirmation"
+  {
+	"#format"   "{1:N}"
+    "ru"        "Ожидание ответа от {lightgreen}{1}{default}..."
+  }
   "No Points"
   {
     "ru"        "У вас нет очков."


### PR DESCRIPTION
Feat: Teammates heal menu (Command: !theal)
Feat: requset points from players
Fix: respect Tank healing limit from the teammates
Fix: skip bots in givepoints command
Fix: incorrect argument for "Insufficient Points" phrase
Fix: !heal command prints empty message if not enough money
Fix: Tank death loop animation caused by !heal command
Fix: E button spamming messages on >30 tickrate servers.
Perf: use events instead forwards